### PR TITLE
do not expose illegal status

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@ var http = require('http');
 
 module.exports = function (value, status, msg, opts) {
   if (value) return;
-  
+
   if (typeof status != 'number') {
     opts = msg;
     msg = status;
     status = 500;
   }
-  
+
   if (typeof msg != 'string') {
     opts = msg;
     msg = http.STATUS_CODES[status];
@@ -16,7 +16,7 @@ module.exports = function (value, status, msg, opts) {
 
   var err = new Error(msg);
   err.status = status;
-  err.expose = status < 500;
+  err.expose = http.STATUS_CODES[status] && status < 500;
   if (opts) merge(err, opts);
   throw err;
 }


### PR DESCRIPTION
make http-assert the same logic with koa.

another is `merge(err, opts)`, in koa's `ctx.throw`, it will ignore `status`, `expose` in opts, http-assert won't. 

seems both make sense to me, but can we make these also as the same logic?
