### PR TITLE
Add assert.fail()

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Comparison (`===`). If `a` and `b` are not equal, an `HttpError`
 is thrown that is constructed with the given `status`, `message`,
 and `properties`.
 
+### assert.fail([status], [message], [properties])
+
+Always throws an `HttpError` that is constructed with the given `status`,
+`message`, and `properties`.
+
 ## Licence
 
 [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -35,3 +35,7 @@ assert.deepEqual = function (a, b, status, msg, opts) {
 assert.notDeepEqual = function (a, b, status, msg, opts) {
   assert(!eql(a, b), status, msg, opts)
 }
+
+assert.fail = function (status, msg, opts) {
+  assert(false, status, msg, opts)
+}

--- a/test/test.js
+++ b/test/test.js
@@ -199,3 +199,18 @@ describe('assert.notDeepEqual()', function () {
     assert.notDeepEqual({ a: 'a' }, { b: 'b' }, 401, 'fail')
   })
 })
+
+describe('assert.fail()', function () {
+  it('should always throw when things fail', function () {
+    var err
+    try {
+      assert.fail(401, 'fail')
+    } catch (e) {
+      err = e
+    }
+
+    ok(err)
+    ok(err.status === 401)
+    ok(err.message === 'fail')
+  })
+})


### PR DESCRIPTION
First off, big [`http-assert`](https://npm.im/http-assert) fan ❤️  I keep meaning to write a blog post about removing as many IF conditions as possible, only possible because of this well-made well-tested library!

Since the native [Node.js assert module](https://nodejs.org/api/assert.html#assert_assert_fail_message) includes a method to "always fail", and this library appears to follow the native assert module pattern (with `strictEqual`, `deepEqual` etc.) here's an addition to the library for `assert.fail()`, following this same pattern.

To avoid use-cases such as:

```js
// Calling with `false` as a constant
const assert = require('http-assert');
assert(false, 401, 'You are unauthorized', { code: 'NOT_AUTHORIZED' });

// Or installing the http-errors library alongside http-assert each time
const createError = require('http-errors');
createError(401, 'You are unauthorized', { code: 'NOT_AUTHORIZED' });
```

Tests & documentation included 🚀 