### PR TITLE
Update http-errors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,9 @@
 unreleased
 ==========
 
-  * deps: http-errors@~1.7.3
+  * deps: http-errors@~1.8.0
     - deps: inherits@2.0.4
+    - deps: setprototypeof@1.2.0
 
 1.4.1 / 2019-04-28
 ==================

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "jshttp/http-assert",
   "dependencies": {
     "deep-equal": "~1.0.1",
-    "http-errors": "~1.7.3"
+    "http-errors": "~1.8.0"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
I changed the range to a caret range so minor version releases of `http-errors` no longer require an `http-assert` release.