### PR TITLE
Faster, smaller `eql`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var createError = require('http-errors')
-var eql = require('deep-equal')
+var eql = require('fast-deep-equal')
 
 module.exports = assert
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": "jshttp/http-assert",
   "dependencies": {
-    "deep-equal": "~1.0.1",
+    "fast-deep-equal": "~3.1.3",
     "http-errors": "~1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The `deep-equal` dependency is both slower (100x) than `fast-deep-equal`
and has a number of obsolete dependencies to polyfill browsers and Node
versions that this project probably doesn’t target/support.

While preferable, trying the native `assert.deepEquals()`, failed the
tests.

If Node.js v8+ is okay (considering v14 oldest current LTS), then moving
to fast-deep-equal with its speed and 0 dependencies seems like a
win-win.