### PR TITLE
chore!: replace deep-equal with dequal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var createError = require('http-errors')
-var eql = require('deep-equal')
+var dequal = require('dequal')
+
+var eql = dequal.dequal
 
 module.exports = assert
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": "jshttp/http-assert",
   "dependencies": {
-    "deep-equal": "~1.0.1",
+    "dequal": "~2.0.3",
     "http-errors": "~1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Replaces [bloated](https://packagephobia.com/result?p=deep-equal) deep-equal module with [much smaller](https://packagephobia.com/result?p=dequal) alternative dequal.

Please note that dequal requires Node.js 6.0 so if Node 0.8 is indeed still supported, this should be considered a breaking change.