### PR TITLE
chore(ci): npm-publish via reusable workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,14 @@
+name: Publish package to npm
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    uses: expressjs/ci-workflows/.github/workflows/release.yml@main
+    secrets:
+      NPM_PUBLISH: ${{ secrets.NPM_PUBLISH }}


### PR DESCRIPTION
Use central reusable workflow to publish on npm with 2fa